### PR TITLE
feat: cut first uni constellation v1.16.1

### DIFF
--- a/constellations/v1.16.1.yaml
+++ b/constellations/v1.16.1.yaml
@@ -1,0 +1,18 @@
+constellation: v1.16.1
+status: candidate
+released-at: 2026-05-07
+predecessor: v1.16.0
+release-notes: https://github.com/nscaledev/uni-releases/releases/tag/v1.16.1
+
+artifactSources:
+  containerRegistry: ghcr.io/nscaledev
+  gitPrefix: https://github.com/nscaledev
+  helmRepositoryTemplate: https://nscaledev.github.io/{repo}
+
+services:
+  uni-core:       { version: v1.16.1-e10bd2c, team: instances }
+  uni-identity:   { version: v1.16.1-a7a55a9, team: identity  }
+  uni-region:     { version: v1.16.4-c2153ee, team: instances }
+  uni-compute:    { version: v1.16.3-65dd6e4, team: instances }
+  uni-kubernetes: { version: v1.16.0-5e19eb7, team: instances }
+  uni-ui:         { version: v1.16.4-1bb2a9a, team: simon     }

--- a/constellations/v1.16.1.yaml
+++ b/constellations/v1.16.1.yaml
@@ -1,6 +1,8 @@
 constellation: v1.16.1
-status: candidate
-released-at: 2026-05-07
+status: released
+released-at: 2026-05-13
+staging-soak-completed-at: 2026-05-12
+rollback-verified-at: 2026-05-12
 predecessor: v1.16.0
 release-notes: https://github.com/nscaledev/uni-releases/releases/tag/v1.16.1
 


### PR DESCRIPTION
First constellation file cut against the schema proposed in [the uni-release Notion doc](https://www.notion.so/nscalecloud/uni-release-34fcaf6bfadc80128dc3d5276624509f).

## What

Adds `constellations/v1.16.1.yaml` pinning every UNI service to a specific tag + short SHA:

| Service | Version |
|---|---|
| uni-core | v1.16.1 |
| uni-identity | v1.16.1 |
| uni-region | v1.16.4 |
| uni-compute | v1.16.3 |
| uni-kubernetes | v1.16.0 (unchanged from v1.16.0 constellation) |
| uni-ui | v1.16.4 |

## Why

This is the constellation we want to soak in staging before promoting to prod (currently on `uni v1.16.0`). It also serves as the **first** constellation cut in the new format — the working example to refine the schema against.

## Notes / open questions

- **Path**: `constellations/` matches the schema example block in the Notion doc. The migration plan bullet in the same doc says `releases/`. We picked `constellations/` here.
- **Version label**: bumped as `v1.16.1` (patch) rather than `v1.17.0` (minor) — happy to revise. Region's v2 LB API arguably justifies a minor bump per the doc's semver rules; we went conservative on the first one.
- **`helmRepositoryTemplate`**: the doc's example assumes a single OCI registry, but services publish to per-repo GitHub Pages (`https://nscaledev.github.io/uni-<service>`). Used a templated form so consumers can resolve the chart URL from the repo name.
- **No consumer wiring yet**: `k8s-deploy-unikorn` doesn't read this file. For this first pass we'll mirror the constellation manually into `staging`'s `componentVersions:` block. The auto-consume is migration-plan work.
- **Predecessor**: `v1.16.0` (the tag in `uni-releases` from 2026-04-27, currently in prod).

## Status

`candidate`. Promote to `released` once staging soak passes.