### PR TITLE
feat: cut uni constellation v1.17.0

### DIFF
--- a/constellations/v1.17.0.yaml
+++ b/constellations/v1.17.0.yaml
@@ -1,0 +1,18 @@
+constellation: v1.17.0
+status: candidate
+released-at: 2026-06-15
+predecessor: v1.16.1
+release-notes: https://github.com/nscaledev/uni-releases/releases/tag/v1.17.0
+
+artifactSources:
+  containerRegistry: ghcr.io/nscaledev
+  gitPrefix: https://github.com/nscaledev
+  helmRepositoryTemplate: https://nscaledev.github.io/{repo}
+
+services:
+  uni-core:       { version: v1.17.0-a3ee500, team: instances }
+  uni-identity:   { version: v1.17.3-98dfab5, team: identity  }
+  uni-region:     { version: v1.17.0-0aa9b7d, team: instances }
+  uni-compute:    { version: v1.16.5-c2f08ae, team: instances }
+  uni-kubernetes: { version: v1.16.3-c3e93f4, team: instances }
+  uni-ui:         { version: v1.16.9-dd14a35, team: simon     }


### PR DESCRIPTION
Follows the constellation format introduced in #73 and cuts a new `v1.17.0` candidate for staging soak.

## What

Adds `constellations/v1.17.0.yaml` pinning every UNI service to a specific tag + short SHA:

| Service | Version |
|---|---|
| uni-core | v1.17.0 |
| uni-identity | v1.17.3 |
| uni-region | v1.17.0 |
| uni-compute | v1.16.5 |
| uni-kubernetes | v1.16.3 |
| uni-ui | v1.16.9 |

## Why

This gives us a single constellation candidate to soak in staging before promotion. The constellation version is `v1.17.0` because core services have moved to the v1.17 line, while downstream services remain pinned to their latest stable v1.16 patch tags.

## Notes

- Uses the `constellations/` path and schema from #73.
- Sets predecessor to `v1.16.1`, matching the prior constellation cut.
- Leaves status as `candidate`; soak, rollback, and release metadata can be added when staging validation completes.

## Status

`candidate`
